### PR TITLE
Message Transformer

### DIFF
--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/MessageTransformer.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/MessageTransformer.java
@@ -1,0 +1,48 @@
+package de.wuespace.telestion.project.daedalus2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.extension.mavlink.message.MavlinkMessage;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+public class MessageTransformer extends AbstractVerticle {
+	private Configuration configuration;
+
+	@SuppressWarnings("unused")
+	public MessageTransformer() {
+		this(null);
+	}
+
+	public MessageTransformer(Configuration configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		var eb = vertx.eventBus();
+
+		this.configuration = Config.get(this.configuration, config(), Configuration.class);
+
+		eb.consumer(this.configuration.inAddress(), raw -> JsonMessage.on(MavlinkMessage.class, raw, message -> {
+			var beautifulMessage = new TransformedMessage("fjei");
+			eb.publish(this.configuration.outAddress(), beautifulMessage.json());
+		}));
+
+
+		startPromise.complete();
+	}
+
+	public record Configuration(
+			@JsonProperty
+			String inAddress,
+			@JsonProperty
+			String outAddress
+	) implements JsonMessage {
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null);
+		}
+	}
+}

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/TransformedMessage.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/TransformedMessage.java
@@ -1,0 +1,10 @@
+package de.wuespace.telestion.project.daedalus2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+public record TransformedMessage(
+		@JsonProperty
+		String zeug
+) implements JsonMessage {
+}


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

A verticle to transform data parsed by the MavLink implementation to data formatted to be saved and easily queried in the database (i.e., a sort of middleware between message parser and DB)

### Details <!-- Describe the content of the pull request -->

The verticle gets configured using an `inAddress`, on which it listens for messages, which then get transformed and published to `outAddress`.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
