### PR TITLE
feat(config): Add import configuration fields for database

### DIFF
--- a/application/conf/config.json
+++ b/application/conf/config.json
@@ -1,30 +1,59 @@
 {
   "org.telestion.configuration": {
-    "app_name": "telestion-project-daedalus2",
-    "verticles": [
-      {
-        "name": "Message Logger",
-        "verticle": "de.wuespace.telestion.services.monitoring.MessageLogger",
-        "magnitude": 1,
-        "config": {}
-      },
-      {
-        "name": "Random Position Publisher",
-        "verticle": "de.wuespace.telestion.example.RandomPositionPublisher",
-        "magnitude": 1,
-        "config": {}
-      },
-      {
-        "name": "Eventbus Tcp Bridge",
-        "verticle": "de.wuespace.telestion.services.connection.EventbusTcpBridge",
-        "magnitude": 1,
-        "config": {
-          "host": "0.0.0.0",
-          "port": 9870,
-          "inboundPermitted": [],
-          "outboundPermitted": []
-        }
-      }
-    ]
+	"app_name": "telestion-project-daedalus2",
+	"verticles": [
+	  {
+		"name": "Message Logger",
+		"verticle": "de.wuespace.telestion.services.monitoring.MessageLogger",
+		"magnitude": 1,
+		"config": {}
+	  },
+	  {
+		"name": "Data Listener",
+		"verticle": "de.wuespace.telestion.services.database.DataListener",
+		"magnitude": 1,
+		"config": {
+		  "listeningAddresses": [
+			"addresses of the split System_t data e.g. IMU, ..."
+		  ]
+		}
+	  },
+	  {
+		"name": "Mongo Database Service",
+		"verticle": "de.wuespace.telestion.services.database.MongoDatabaseService",
+		"magnitude": 1,
+		"config": {
+		  "dbConfig": {
+			"db_name": "daedalus2",
+			"useObjectId": true
+		  },
+		  "dbPoolName": "d2Pool"
+		}
+	  },
+	  {
+		"name": "Periodic Data Publisher (e.g. IMU) config needed for each desired data type",
+		"verticle": "de.wuespace.telestion.services.database.PeriodicDataPublisher",
+		"magnitude": 1,
+		"config": {
+		  "collection": "de.wuespace.telestion.project.daedalus2.<Location of DataType/Record/JsonMessage>",
+		  "query": "",
+		  "fields": [],
+		  "sort": [],
+		  "rate": 1,
+		  "outAddress": "desired output address (important for frontend)"
+		}
+	  },
+	  {
+		"name": "Eventbus Tcp Bridge",
+		"verticle": "de.wuespace.telestion.services.connection.EventbusTcpBridge",
+		"magnitude": 1,
+		"config": {
+		  "host": "0.0.0.0",
+		  "port": 9870,
+		  "inboundPermitted": [],
+		  "outboundPermitted": []
+		}
+	  }
+	]
   }
 }

--- a/application/conf/config.json
+++ b/application/conf/config.json
@@ -9,12 +9,81 @@
 		"config": {}
 	  },
 	  {
+		"name": "Serial Receiver",
+		"verticle": "de.wuespace.telestion.services.connection.rework.serial.SerialConn",
+		"magnitude": 1,
+		"config": {
+		  "inAddress": "n/a (not a real address)",
+		  "outAddress": "raw-serial",
+		  "serialPort": "COM1",
+		  "sampleTime": 200
+		}
+	  },
+	  {
+		"name": "Serial Splitter",
+		"verticle": "de.wuespace.telestion.project.daedalus2.SerialSplitter",
+		"magnitude": 1,
+		"config": {
+		  "longestMessageLength": 280,
+		  "inAddress": "raw-serial",
+		  "outAddress": "nice-serial"
+		}
+	  },
+	  {
+		"name": "Mavlink v2 Validator",
+		"verticle": "de.wuespace.telestion.extension.mavlink.ValidatorMavlink2",
+		"magnitude": 1,
+		"config": {
+		  "inAddress": "nice-serial",
+		  "packetOutAddress": "mavlink-raw-logger",
+		  "parserInAddress": "mavlink-payload-parser-in",
+		  "password": "AQ=="
+		}
+	  },
+	  {
+		"name": "MavLink Logger",
+		"verticle": "de.wuespace.telestion.extension.mavlink.logger.RawLogger",
+		"magnitude": 1,
+		"config": {
+		  "inAddress": "mavlink-raw-logger",
+		  "filePath": "data/mavlink-logger/"
+		}
+	  },
+	  {
+		"name": "Payload Parser",
+		"verticle": "de.wuespace.telestion.extension.mavlink.PayloadParser",
+		"magnitude": 1,
+		"config": {
+		  "inAddress": "mavlink-payload-parser-in",
+		  "outAddress": "parsed-payload"
+		}
+	  },
+	  {
+		"name": "Mavlink Message Registrar",
+		"verticle": "de.wuespace.telestion.project.daedalus2.mavlink.MavlinkRegistrar",
+		"magnitude": 1,
+		"config": {
+		  "classNames": [
+			"de.wuespace.telestion.project.daedalus2.mavlink.SeedSystemT"
+		  ]
+		}
+	  },
+	  {
+		"name": "MessageTransformer",
+		"verticle": "de.wuespace.telestion.project.daedalus2.MessageTransformer",
+		"magnitude": 1,
+		"config": {
+		  "inAddress": "parsed-payload",
+		  "outAddress": "beautiful-data"
+		}
+	  },
+	  {
 		"name": "Data Listener",
 		"verticle": "de.wuespace.telestion.services.database.DataListener",
 		"magnitude": 1,
 		"config": {
 		  "listeningAddresses": [
-			"addresses of the split System_t data e.g. IMU, ..."
+			"beautiful-data"
 		  ]
 		}
 	  },
@@ -23,24 +92,18 @@
 		"verticle": "de.wuespace.telestion.services.database.MongoDatabaseService",
 		"magnitude": 1,
 		"config": {
-		  "dbConfig": {
-			"db_name": "daedalus2",
-			"useObjectId": true
-		  },
 		  "dbPoolName": "d2Pool"
 		}
 	  },
 	  {
-		"name": "Periodic Data Publisher (e.g. IMU) config needed for each desired data type",
-		"verticle": "de.wuespace.telestion.services.database.PeriodicDataPublisher",
+		"name": "Periodic Data Aggregator",
+		"verticle": "de.wuespace.telestion.services.database.PeriodicDataAggregator",
 		"magnitude": 1,
 		"config": {
-		  "collection": "de.wuespace.telestion.project.daedalus2.<Location of DataType/Record/JsonMessage>",
-		  "query": "",
-		  "fields": [],
-		  "sort": [],
-		  "rate": 1,
-		  "outAddress": "desired output address (important for frontend)"
+		  "collection": "de.wuespace.telestion.project.daedalus2.messages.SystemT",
+		  "field": "imu.acc.x",
+		  "rate": 10,
+		  "outAddress": "aggregated-imu.acc.x"
 		}
 	  },
 	  {
@@ -51,7 +114,7 @@
 		  "host": "0.0.0.0",
 		  "port": 9870,
 		  "inboundPermitted": [],
-		  "outboundPermitted": []
+		  "outboundPermitted": ["aggregated-imu.acc.x", "aggregated-imu.acc.y"]
 		}
 	  }
 	]


### PR DESCRIPTION
No final version, only helper for the final configuration.

### Summary

Configuration for daedalus2 project including database and periodic data publishing.

### Details

Important changes to config.json to get the database verticles running.

### Additional information

### Related links

- Fixes # .

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
