### PR TITLE
Adjust client to new format of "aggregated data sample" and listen to "real" event bus addresses

### DIFF
--- a/client/src/lib/fake-data-generator.ts
+++ b/client/src/lib/fake-data-generator.ts
@@ -80,7 +80,8 @@ export class FakeDataGenerator {
 			avg: this.lastAvg + avgNoise,
 			min: this.lastMin + minNoise,
 			max: this.lastMax + maxNoise,
-			timeStamp: thisCall
+			last: this.lastAvg + maxNoise,
+			time: thisCall
 		};
 	}
 }

--- a/client/src/lib/gen-fake-data.ts
+++ b/client/src/lib/gen-fake-data.ts
@@ -55,6 +55,7 @@ export function genFakeData(): DataSample {
 		avg: avg + avgNoise,
 		min: min + minNoise,
 		max: max + maxNoise,
-		timeStamp: thisCall
+		last: avg,
+		time: thisCall
 	};
 }

--- a/client/src/lib/gen-random-data.ts
+++ b/client/src/lib/gen-random-data.ts
@@ -18,6 +18,7 @@ export function genRandomData(): DataSample {
 		avg,
 		min,
 		max,
-		timeStamp: Date.now()
+		last: max,
+		time: Date.now()
 	};
 }

--- a/client/src/model/dashboards/widget-props/pgraph-props.ts
+++ b/client/src/model/dashboards/widget-props/pgraph-props.ts
@@ -3,22 +3,22 @@ import { PGraphWidgetProps } from '../../../widgets/pgraph-widget';
 export const fakeProps: PGraphWidgetProps = {
 	connections: [
 		{
-			address: 'fake-channel1',
-			title: 'Fake Data 1',
+			address: 'aggregated-imu.acc.x',
+			title: 'Accelerometer X',
 			stroke: 'orange-700',
 			fill: 'orange-400'
 		},
 		{
-			address: 'fake-channel2',
-			title: 'Fake Data 2',
-			stroke: 'celery-700',
-			fill: 'celery-400'
-		},
-		{
-			address: 'fake-channel3',
-			title: 'Fake Data 3',
+			address: 'aggregated-imu.acc.y',
+			title: 'Accelerometer Y',
 			stroke: 'seafoam-700',
 			fill: 'seafoam-400'
+		},
+		{
+			address: 'aggregated-imu.acc.z',
+			title: 'Accelerometer Z',
+			stroke: 'blue-700',
+			fill: 'blue-400'
 		}
 	],
 	period: 2 * 60 * 1000,

--- a/client/src/model/data-sample.ts
+++ b/client/src/model/data-sample.ts
@@ -14,7 +14,11 @@ export interface DataSample extends Record<string, JsonSerializable> {
 	 */
 	max: number;
 	/**
-	 * The time stamp of the last data sample in the aggregation.
+	 * The latest (last) value in the aggregation
 	 */
-	timeStamp: number;
+	last: number;
+	/**
+	 * The time of the last data sample in the aggregation.
+	 */
+	time: number;
 }

--- a/client/src/plugins/mock-server-plugin.ts
+++ b/client/src/plugins/mock-server-plugin.ts
@@ -6,9 +6,9 @@ import { FakeDataGenerator } from '../lib/fake-data-generator';
 class RocketSoundMockServer extends MockServer implements OnInit, OnClose {
 	intervalId: any;
 
-	readonly fakeChannel1 = 'fake-channel1';
-	readonly fakeChannel2 = 'fake-channel2';
-	readonly fakeChannel3 = 'fake-channel3';
+	readonly fakeChannel1 = 'aggregated-imu.acc.x';
+	readonly fakeChannel2 = 'aggregated-imu.acc.y';
+	readonly fakeChannel3 = 'aggregated-imu.acc.z';
 
 	readonly fakeDataGen1: FakeDataGenerator;
 	readonly fakeDataGen2: FakeDataGenerator;

--- a/client/src/widgets/pgraph-widget/hooks/use-dynamic-data.ts
+++ b/client/src/widgets/pgraph-widget/hooks/use-dynamic-data.ts
@@ -65,7 +65,7 @@ export function useDynamicData(
 					storeRef[index].push(...newSamples);
 					// calculate minimum and maximum timestamp
 					dimensionsRef.maxX = Math.max(
-						d3.max(newSamples.map(sample => sample.timeStamp)) as number,
+						d3.max(newSamples.map(sample => sample.time)) as number,
 						dimensions.current.maxX
 					);
 					dimensionsRef.minX = dimensionsRef.maxX - period;

--- a/client/src/widgets/pgraph-widget/lib/create-node.ts
+++ b/client/src/widgets/pgraph-widget/lib/create-node.ts
@@ -83,7 +83,7 @@ export function createNode(
 			const backRender = d3
 				.area<DataSample>()
 				.curve(d3.curveLinear)
-				.x(d => x(d.timeStamp))
+				.x(d => x(d.time))
 				.y0(d => y(d.min))
 				.y1(d => y(d.max));
 
@@ -91,7 +91,7 @@ export function createNode(
 			const lineRender = d3
 				.line<DataSample>()
 				.curve(d3.curveLinear)
-				.x(d => x(d.timeStamp))
+				.x(d => x(d.time))
 				.y(d => y(d.avg));
 
 			// update all graph nodes with current data

--- a/client/src/widgets/pgraph-widget/lib/remove-old-samples.ts
+++ b/client/src/widgets/pgraph-widget/lib/remove-old-samples.ts
@@ -10,6 +10,6 @@ export function removeOldSamples(
 	min: number
 ): DataSample[][] {
 	return store.map(connection =>
-		connection.filter(sample => sample.timeStamp > min)
+		connection.filter(sample => sample.time > min)
 	);
 }


### PR DESCRIPTION
This adjusts the implementations to match the new implementations in the `application`.

## Example of the new data sample
```js
{
  min:0
  avg:0
  max:0
  last:0
  time:1620574226962
}
```

## Contributor's License Agreement
- [x] I have read and signed the WüSpace ICLA