### PR TITLE
Iridium Message Mapper

### DIFF
--- a/application/conf/config.json
+++ b/application/conf/config.json
@@ -135,6 +135,20 @@
 				}
 			},
 			{
+				"name": "[DATA] Iridium Message Mapper for Redis",
+				"verticle": "de.wuespace.telestion.project.daedalus2.iridium.MessageMapper",
+				"magnitude": 1,
+				"config": {
+					"inAddress": "iridium-messages",
+					"imeiMapping": {
+						"3132333435363738397A657A647666": "simulator",
+						"300434062562930": "testboard1",
+						"333030343334303632353631393830": "seedA",
+						"???": "seedB"
+					}
+				}
+			},
+			{
 				"name": "[DATA] Redis Saver",
 				"verticle": "de.wuespace.telestion.project.daedalus2.redis.RedisSaver",
 				"magnitude": 1,

--- a/application/conf/config.json
+++ b/application/conf/config.json
@@ -159,12 +159,15 @@
 						"seedA/SEED_HEARTBEAT",
 						"seedA/SEED_LOG",
 						"seedA/SEED_SYSTEM_T",
+						"seedA/iridium",
 						"seedB/SEED_HEARTBEAT",
 						"seedB/SEED_LOG",
 						"seedB/SEED_SYSTEM_T",
+						"seedB/iridium",
 						"ejector/EJECTOR_HEARTBEAT",
 						"ejector/EJECTOR_LOG",
-						"ejector/EJECTOR_SYSTEM_T"
+						"ejector/EJECTOR_SYSTEM_T",
+						"testboard1/iridium"
 					]
 				}
 			},
@@ -197,12 +200,15 @@
 						"seedA/SEED_HEARTBEAT",
 						"seedA/SEED_LOG",
 						"seedA/SEED_SYSTEM_T",
+						"seedA/iridium",
 						"seedB/SEED_HEARTBEAT",
 						"seedB/SEED_LOG",
 						"seedB/SEED_SYSTEM_T",
+						"seedB/iridium",
 						"ejector/EJECTOR_HEARTBEAT",
 						"ejector/EJECTOR_LOG",
-						"ejector/EJECTOR_SYSTEM_T"
+						"ejector/EJECTOR_SYSTEM_T",
+						"testboard1/iridium"
 					]
 				}
 			},

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/MappedMessage.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/MappedMessage.java
@@ -1,0 +1,16 @@
+package de.wuespace.telestion.project.daedalus2.iridium;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IEHeader;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IELocation;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IEPayload;
+
+public record MappedMessage(
+		@JsonProperty IEHeader header,
+		@JsonProperty IEPayload payload,
+		@JsonProperty IELocation location) implements JsonMessage {
+	public MappedMessage() {
+		this(null, null, null);
+	}
+}

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/MessageMapper.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/MessageMapper.java
@@ -1,0 +1,78 @@
+package de.wuespace.telestion.project.daedalus2.iridium;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IEHeader;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IELocation;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IEPayload;
+import de.wuespace.telestion.project.daedalus2.iridium.message.IridiumMessage;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MessageMapper extends AbstractVerticle {
+	private record Configuration(@JsonProperty String inAddress, @JsonProperty Map<String, String> imeiMapping) {
+		private Configuration() {
+			this(null, new HashMap<>());
+		}
+	}
+
+	@Override
+	public void start(Promise<Void> startPromise) throws Exception {
+		this.config = Config.get(this.config, new Configuration(), config(), Configuration.class);
+		vertx.eventBus().consumer(config.inAddress(), raw -> JsonMessage.on(IridiumMessage.class, raw, this::handleMessage));
+		startPromise.complete();
+	}
+
+	public MessageMapper(Configuration forcedConfig) {
+		this.config = forcedConfig;
+	}
+
+	public MessageMapper() {
+		this(null);
+	}
+
+	private final Logger logger = LoggerFactory.getLogger(MessageMapper.class);
+	private Configuration config;
+
+	private void handleMessage(IridiumMessage msg) {
+		IEHeader header = null;
+		IEPayload payload = null;
+		IELocation location = null;
+
+		for (var elem : msg.elements()) {
+			if (elem instanceof IEHeader) {
+				header = (IEHeader) elem;
+			} else if (elem instanceof IEPayload) {
+				payload = (IEPayload) elem;
+			} else if (elem instanceof IELocation) {
+				location = (IELocation) elem;
+			} else {
+				logger.warn("Unknown information element type. Ignoring");
+			}
+		}
+
+		if (header == null) {
+			logger.warn("Header not found on current message. " +
+					"Cannot assign mapped message to current device");
+		}
+
+		if (payload == null) {
+			logger.info("Message with no payload received. Continuing as normal");
+		}
+
+		if (location == null) {
+			logger.info("Iridium location information missing. Continuing as normal");
+		}
+
+		var mapped = header != null
+				? config.imeiMapping().getOrDefault(header.imei(), "unknown")
+				: "unknown";
+		vertx.eventBus().publish(mapped + "/iridium", new MappedMessage(header, payload, location).json());
+	}
+}

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/message/IEHeader.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/iridium/message/IEHeader.java
@@ -55,12 +55,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @SuppressWarnings("unused")
 public record IEHeader(
-		@JsonProperty int cdr,
+		@JsonProperty long cdr,
 		@JsonProperty String imei,
 		@JsonProperty int session_status,
-		@JsonProperty short momsn,
-		@JsonProperty short mtmsn,
-		@JsonProperty int time
+		@JsonProperty int momsn,
+		@JsonProperty int mtmsn,
+		@JsonProperty long time
 ) implements InformationElement {
 	private IEHeader() {
 		this(-1, null, -1, (short) -1, (short) -1, -1);


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

A verticle, which maps the decoded data from the Iridium SBD receiver to a Redis storable and readable format.

### Details <!-- Describe the content of the pull request -->

The `MessageMapper` verticle reads the combined information elements from the SDB receiver (decoded from the Iridium `MessageParser`) and maps them into a readable format for the Redis database.

Every message is then published to different eventbus channels based on the IMEI in the IE header.
This can be configured via the `imeiMapping` property in the verticle.
It maps the received IMEI to a human-readable channel name part.

The channel name contains the source of the message concatenated with `/iridium`. (e.g. `seedA/iridium` or `simulator/iridium`).
If the source is not known (e.g. not in the `imeiMapping` or no IE header was received) the channel address is `unknown/iridium`.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

The PR was tested with the Iridium SDB receiver and a simulator which sends packed Iridium messages.

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
