### PR TITLE
Telecommand Sender with correct MAVLink messages

### DIFF
--- a/application/assist-now-generator/.gitignore
+++ b/application/assist-now-generator/.gitignore
@@ -1,0 +1,2 @@
+# generated content
+assist-now*

--- a/application/assist-now-generator/main.py
+++ b/application/assist-now-generator/main.py
@@ -1,0 +1,21 @@
+import time
+import base64
+
+title = "Testnachricht" + "\n"
+message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam felis turpis, auctor quis suscipit id, \
+dapibus nec nibh. Nunc eget leo dictum, eleifend erat et, sagittis dolor. Nulla facilisi. Quisque lacinia maximus \
+nulla in gravida. Ut dapibus aliquet luctus. Quisque quis vehicula odio, ut tincidunt orci. Orci varius natoque \
+penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi massa justo, mattis sed eleifend vitae, \
+malesuada id risus. Quisque vestibulum faucibus sagittis. In tellus tellus, suscipit eu convallis ut, auctor ut \
+augue. Maecenas quis neque ex. Pellentesque lacinia laoreet nisl, et lacinia elit molestie at. Praesent eleifend diam \
+at mauris pellentesque luctus."
+
+time = time.strftime("%Y-%m-%d-%H_%M_%S%z")
+raw = message.encode("ascii")
+encoded = base64.b64encode(raw)
+
+# write file
+file = open("assist-now-" + time + ".bin", "wb")
+file.write(title.encode("ascii"))
+file.write(encoded)
+file.close()

--- a/application/d2-tm-sim/main.py
+++ b/application/d2-tm-sim/main.py
@@ -16,6 +16,11 @@ SEED_B_ID = 6
 
 STOP_FLAG = False
 
+sourceIds = {
+	SEED_A_ID: "seedA",
+	SEED_B_ID: "seedB",
+	EJECTOR_ID: "ejector"
+}
 
 def receive(name, s: socket.socket, file: BinaryIO):
 	print("Starting receive thread " + str(name))
@@ -27,10 +32,21 @@ def receive(name, s: socket.socket, file: BinaryIO):
 			raw = s.recv(1)
 			message = tc_receiver.parse_char(raw)
 			if message:
-				print("\nReceived to {0} message: {1}".format(message.get_header().srcComponent, str(message)))
+				sourceId = message.get_header().srcComponent
+				msgSource = sourceIds.get(sourceId, "unknown")
+				if hasattr(message, "ublox_msg"):
+					msgType = "ublox_msg"
+					msgContent = bytearray(message.ublox_msg).strip(b"\x00")
+				elif hasattr(message, "con_cmd"):
+					msgType = "con_cmd"
+					msgContent = message.con_cmd
+				else:
+					msgType = "generic"
+					msgContent = message
+
+				print("\nReceived a '{0}' message to '{1}' with: {2}".format(msgType, msgSource, msgContent))
 	except:
 		return None
-
 
 def loop():
 	s: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/gps/message/ResponseTransmission.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/gps/message/ResponseTransmission.java
@@ -21,6 +21,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *               		<td><code>2</code></td>
  *               		<td>No A-GPS data to upload</td>
  *               	</tr>
+ *               	<tr>
+ *               		<td><code>3</code></td>
+ *               		<td>No target to transmit data to</td>
+ *               	</tr>
+ *               	<tr>
+ *               		<td><code>4</code></td>
+ *               		<td>Cannot split binary blob</td>
+ *               	</tr>
+ *               	<tr>
+ *               		<td><code>5</code></td>
+ *               		<td>Cannot decode uploaded data (not base64)</td>
+ *               	</tr>
  *               </table>
  */
 @SuppressWarnings("unused")

--- a/application/src/main/java/de/wuespace/telestion/project/daedalus2/mavlink/internal/AssistNowTelecommand.java
+++ b/application/src/main/java/de/wuespace/telestion/project/daedalus2/mavlink/internal/AssistNowTelecommand.java
@@ -1,0 +1,10 @@
+package de.wuespace.telestion.project.daedalus2.mavlink.internal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+public record AssistNowTelecommand(@JsonProperty String target, @JsonProperty byte[] rawData) implements JsonMessage {
+	public AssistNowTelecommand() {
+		this(null, null);
+	}
+}

--- a/client/src/model/a-gps.ts
+++ b/client/src/model/a-gps.ts
@@ -79,7 +79,7 @@ export interface ResponseNewTarget extends AGpsResponseBase {
 
 export interface ResponseTransmission extends AGpsResponseBase {
 	type: 'transmission';
-	result: 0 | 1 | 2 | 3 | 4;
+	result: 0 | 1 | 2 | 3 | 4 | 5;
 	className: 'de.wuespace.telestion.project.daedalus2.gps.message.ResponseTransmission';
 }
 

--- a/client/src/widgets/a-gps-widget/use-a-gps-reducers.ts
+++ b/client/src/widgets/a-gps-widget/use-a-gps-reducers.ts
@@ -97,6 +97,9 @@ export function useAGpsReducers(): WidgetReducers {
 					case 4:
 						alert('Cannot split binary blob');
 						break;
+					case 5:
+						alert('Invalid data uploaded. Cannot transmit');
+						break;
 				}
 			}
 		});


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Update TelecommandSender and AGPSTransmitter to use the right MAVLink messages on transmission.

### Details <!-- Describe the content of the pull request -->

- Update TelecommandSender verticle to also handle `AssistNowTelecommand` message which are converted to an encoded MAVLink `msg_assist_now_upload` message.
- The AGPSTransmitter verticle now uses this message type to transmit the Assist Now GPS data in chunks.
- A bug in the AGPSTransmitter which breaks the verticle if invalid encoded messages are uploaded through the Client widget is also fixed.
- This PR now includes a AGPS binary file generator with user definable content. (see https://github.com/wuespace/telestion-project-daedalus2/commit/c66a1e9a6e11f6cd669ea2daeab8e41285aef690 for more information)
- The MAVLink D2 Simulator is also updated to handle the new receive messages.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
