### PR TITLE
Client configuration

### DIFF
--- a/client/public/config.json
+++ b/client/public/config.json
@@ -1,0 +1,4 @@
+{
+	"initialServerURL": "http://localhost:9870/bridge",
+	"initialUsername": "admin"
+}

--- a/client/src/components/login-page.tsx
+++ b/client/src/components/login-page.tsx
@@ -5,16 +5,19 @@ import {
 	LoginDescription,
 	LoginForm
 } from '@wuespace/telestion-client-common';
+import { useConfig } from '../hooks/use-config';
 
 export function LoginPage() {
+	const config = useConfig();
+
 	return (
 		<TCLoginPage>
 			<LoginLogo />
 			<LoginTitle />
 			<LoginDescription />
 			<LoginForm
-				initialServerURL="http://localhost:9870/bridge"
-				initialUsername="admin"
+				initialServerURL={config.initialServerURL}
+				initialUsername={config.initialUsername}
 			/>
 		</TCLoginPage>
 	);

--- a/client/src/hooks/use-config.ts
+++ b/client/src/hooks/use-config.ts
@@ -1,0 +1,30 @@
+import { loadSync } from '../lib/load-sync';
+
+export interface Config {
+	initialServerURL: string;
+	initialUsername: string;
+}
+
+export const defaultConfig: Config = {
+	initialServerURL: 'http://localhost:9870/bridge',
+	initialUsername: 'admin'
+};
+
+function loadConfig(): Config {
+	const result = loadSync('./config.json', 'application/json');
+	if (!result) return defaultConfig;
+
+	try {
+		const parsed = JSON.parse(result);
+		// if the administrator forgets some configuration variables
+		return { ...defaultConfig, ...parsed };
+	} catch (e) {
+		return defaultConfig;
+	}
+}
+
+const config = loadConfig();
+
+export function useConfig() {
+	return config;
+}

--- a/client/src/lib/load-sync.ts
+++ b/client/src/lib/load-sync.ts
@@ -1,0 +1,15 @@
+export function loadSync(filePath: string, mimeType: string): string | null {
+	const xmlhttp = new XMLHttpRequest();
+	xmlhttp.open('GET', filePath, false);
+	if (mimeType != null) {
+		if (xmlhttp.overrideMimeType) {
+			xmlhttp.overrideMimeType(mimeType);
+		}
+	}
+	xmlhttp.send();
+	if (xmlhttp.status === 200) {
+		return xmlhttp.responseText;
+	} else {
+		return null;
+	}
+}


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Add configuration that loads synchronous with the initial page and reads the `config.json` in the webroot to initially configure the web client.

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
